### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# Filesentry
+# FileSentry
 
 <p align="center">
   <img src="filesentry.png" width="300px">
 </p>
 
-Filesentry is a rust library  that enables reliably watching files (potenitally recrusively) for changes. It goes to great lengths to ensure no events are missed/dropped. Filsentry is intentionally limited to watching whether **files** are: modified, created or deleted. More detailed events are intentionally not recorded as they tend to be missleading. For example a write from applications like vim that first write to a temporary file can show up as a move, with file sentry it shows up as a `Modify` event.
+FileSentry is a rust library  that enables reliably watching files (potentially recursively) for changes. It goes to great lengths to ensure no events are missed/dropped. FileSentry is intentionally limited to watching whether **files** are: modified, created or deleted. More detailed events are intentionally not recorded as they tend to be misleading. For example a write from applications like Vim that first write to a temporary file can show up as a move, with file sentry it shows up as a `Modify` event.
 
 ## Details 
 
 
-To achieve reliability filesentry will buildup an in-memory view of the filesystem by running a recursive crawl when it starts watching a directory. When a filewatcher event occurs filesentry will examine (stat) the respective path and compare it to the in-memory view. This will serve as the source of truth for whether the entry was created/deleted/modified (or turned into a directory). If a new directory is created (or it's inode number changed) the directory is also crawled again.
+To achieve reliability FileSentry will buildup an in-memory view of the filesystem by running a recursive crawl when it starts watching a directory. When a file watcher event occurs FileSentry will examine (stat) the respective path and compare it to the in-memory view. This will serve as the source of truth for whether the entry was created/deleted/modified (or turned into a directory). If a new directory is created (or its inode number changed) the directory is also crawled again.
 
-When an event is record it is first aggregated and merged in an internal collection. There events are merged until the file-watcher has settled (no events for N milliseconds). This ensures that duplicate events are removed and for example means that replacing file A with file B turns into a `Delete` event for `file A` and a `Modify` event for `file B`.
+When an event is record it is first aggregated and merged in an internal collection. The events are merged until the file-watcher has settled (no events for N milliseconds). This ensures that duplicate events are removed and for example means that replacing file A with file B turns into a `Delete` event for `file A` and a `Modify` event for `file B`.
 
-On all platforms the native file-watching APIs involve one or multiple queues (often in the kernel but sometimes in userspace aswell). If the system is heavily loaded these queues can overflow which in most filewatchers leads to missed events and often desynchronized states. Filesentry solves this by triggering a recursive recrawls in tis case. As we keep a copy of the file-tree in memory we can always compare the stat information read during a crawl with the in-memory representation and generate events based on the differences.
+On all platforms the native file-watching APIs involve one or multiple queues (often in the kernel but sometimes in user space as well). If the system is heavily loaded these queues can overflow which in most file watchers leads to missed events and often de-synchronized states. FileSentry solves this by triggering a recursive re-crawls in this case. As we keep a copy of the file-tree in memory we can always compare the stat information read during a crawl with the in-memory representation and generate events based on the differences.
 
 
-This approach is heavily inspired by `watchman` which is the most sophisticated/reliable filewatcher I am aware of.
+This approach is heavily inspired by `watchman` which is the most sophisticated/reliable file watcher I am aware of.
 
 ## Backends
 
-Currently, only linux with `inotify` is supported but support for mac with `fsevent` and windows is planned. 
+Currently, only Linux with `inotify` is supported but support for macOS with `fsevent` and Windows is planned.

--- a/src/events.rs
+++ b/src/events.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 use ecow::EcoVec;
 use hashbrown::{hash_table, DefaultHashBuilder, HashTable};
 
-use crate::path::CannonicalPathBuf;
+use crate::path::CanonicalPathBuf;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
 pub enum EventType {
@@ -16,7 +16,7 @@ pub enum EventType {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Event {
-    pub path: CannonicalPathBuf,
+    pub path: CanonicalPathBuf,
     pub ty: EventType,
 }
 
@@ -36,7 +36,7 @@ impl EventDebouncer {
         }
     }
 
-    pub fn add(&mut self, path: CannonicalPathBuf, ty: EventType) {
+    pub fn add(&mut self, path: CanonicalPathBuf, ty: EventType) {
         let entry = self.table.entry(
             self.hasher.hash_one(&path),
             |&i| self.events[i as usize].path == path,
@@ -47,7 +47,7 @@ impl EventDebouncer {
                 let i = *entry.get() as usize;
                 let event = &mut self.events.make_mut()[i];
                 match (event.ty, ty) {
-                    // temporary file that was created and immidiately removed
+                    // temporary file that was created and immediately removed
                     (EventType::Create, EventType::Delete) => {
                         entry.remove();
                     }

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -9,7 +9,7 @@ use mio::{Poll, Waker};
 use papaya::HashMap;
 
 use crate::inotify::sys::{Event, EventFlags, Inotify, Watch};
-use crate::path::CannonicalPathBuf;
+use crate::path::CanonicalPathBuf;
 use crate::pending::{self, PendingChangesLock};
 use crate::{Filter, WatcherState};
 
@@ -17,7 +17,7 @@ pub(crate) struct InotifyWatcher {
     waker: mio::Waker,
     shutdown: AtomicBool,
     notify: Inotify,
-    watches: HashMap<Watch, CannonicalPathBuf, DefaultHashBuilder>,
+    watches: HashMap<Watch, CanonicalPathBuf, DefaultHashBuilder>,
     pub changes: PendingChangesLock,
 }
 
@@ -78,7 +78,7 @@ impl InotifyWatcher {
         Ok(watcher)
     }
 
-    pub fn watch_dir(&self, path: CannonicalPathBuf) -> io::Result<()> {
+    pub fn watch_dir(&self, path: CanonicalPathBuf) -> io::Result<()> {
         let watch = self.notify.add_directory_watch(&*path)?;
         self.watches.pin().insert(watch, path);
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use crate::config::Config;
 use crate::events::EventDebouncer;
 pub use crate::events::{EventType, Events};
 use crate::inotify::InotifyWatcher;
-pub use crate::path::{CannonicalPath, CannonicalPathBuf};
+pub use crate::path::{CannonicalPath, CanonicalPathBuf};
 use crate::worker::Worker;
 pub use config::Filter;
 
@@ -26,7 +26,7 @@ mod tree;
 mod worker;
 
 struct AddRoot {
-    path: CannonicalPathBuf,
+    path: CanonicalPathBuf,
     recursive: bool,
     notify: Box<dyn FnOnce(bool) + Send>,
 }
@@ -110,7 +110,7 @@ impl Watcher {
             log::warn!("ignoring root {root:?} as it matches the ignore pattern");
             return Ok(());
         }
-        let root = CannonicalPathBuf::assert_cannoncalized(&root);
+        let root = CanonicalPathBuf::assert_canonicalized(&root);
         self.state
             .notifications
             .lock()

--- a/src/pending.rs
+++ b/src/pending.rs
@@ -7,7 +7,7 @@ use bitflags::bitflags;
 use hashbrown::hash_table::Entry;
 use hashbrown::{DefaultHashBuilder, HashTable};
 
-use crate::path::CannonicalPathBuf;
+use crate::path::CanonicalPathBuf;
 
 bitflags! {
     #[derive(Clone, Copy, Debug)]
@@ -15,7 +15,7 @@ bitflags! {
         /// for directories: do a recursive crawl
         const NEEDS_RECURSIVE_CRAWL = 1;
         /// for directories: do a non-recursive crawl, some watchers (fsevent)
-        /// only report that *something* changed in a dricetory but not what,
+        /// only report that *something* changed in a directory but not what,
         /// it's our job to stat.
         const NEEDS_NON_RECURSIVE_CRAWL = 2;
         /// flag set during recursive watch to indicate that nodes should be marked recursive
@@ -71,7 +71,7 @@ impl PendingChangesLock {
 
 #[derive(Clone, Debug)]
 pub struct PendingChange {
-    pub path: CannonicalPathBuf,
+    pub path: CanonicalPathBuf,
     pub flags: Flags,
 }
 
@@ -149,7 +149,7 @@ impl PendingChanges {
 
     pub fn add_watcher(
         &mut self,
-        path: CannonicalPathBuf,
+        path: CanonicalPathBuf,
         /* timestamp: SystemTime, */ flags: Flags,
     ) {
         self.add(PendingChange {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -62,7 +62,7 @@ impl Worker {
                     continue;
                 };
                 if let Err(err) = self.watcher.notify.watch_dir(root.path.clone()) {
-                    log::error!("faild to watch {:?}: {err}", root.path);
+                    log::error!("failed to watch {:?}: {err}", root.path);
                     (root.notify)(false);
                     continue;
                 }
@@ -70,7 +70,7 @@ impl Worker {
                 self.tree
                     .crawl_root(node, root.recursive, &*filter, |path| {
                         if let Err(err) = self.watcher.notify.watch_dir(path.clone()) {
-                            log::error!("faild to watch {path:?}: {err}")
+                            log::error!("failed to watch {path:?}: {err}")
                         }
                     });
                 let i = self
@@ -94,12 +94,12 @@ impl Worker {
 
     pub fn run(mut self) {
         loop {
-            let setteled = self.wait_for_changes();
+            let settled = self.wait_for_changes();
             if self.watcher.notify.is_shutdown() {
                 break;
             }
             self.process_notifications();
-            if setteled {
+            if settled {
                 let events = self.events.take();
                 self.watcher
                     .state
@@ -126,7 +126,7 @@ impl Worker {
                         |path, ty| self.events.add(path, ty),
                         |path| {
                             if let Err(err) = self.watcher.notify.watch_dir(path.clone()) {
-                                log::error!("faild to watch {path:?}: {err}")
+                                log::error!("failed to watch {path:?}: {err}")
                             }
                         },
                     );
@@ -140,7 +140,7 @@ impl Worker {
                 &mut self.work_stack,
                 |path| {
                     if let Err(err) = self.watcher.notify.watch_dir(path.clone()) {
-                        log::error!("faild to watch {path:?}: {err}")
+                        log::error!("failed to watch {path:?}: {err}")
                     }
                 },
             );


### PR DESCRIPTION
A few minor typo fixes here, a la spellbook. Mostly in the docs but also a bigger one that affected a lot of the crate in 'canonicalized'