### PR TITLE
add macOS FSEvents file watcher backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,17 @@ walkdir = "2.3.3"
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "1.0.7", features = ["fs"] }
 
+# Linux + macOS (pending.rs uses bitflags on both platforms)
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+bitflags = "2.9.0"
+
 # Linux-only (inotify module)
 [target.'cfg(target_os = "linux")'.dependencies]
-bitflags = "2.9.0"
 papaya = "0.2.1"
 mio = { version = "1.0.4", features = ["os-ext"] }
-ignore = "0.4.23"
-
 
 [dev-dependencies]
+ignore = "0.4.23"
 tempfile = "3.20.0"
 pretty_assertions = "1.4.1"
 env_logger = "0.11.8"

--- a/build.rs
+++ b/build.rs
@@ -3,9 +3,9 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(watcher_disable)");
 
     // Disable the watcher if:
-    // 1. We're not on Linux (inotify is Linux-only)
+    // 1. We're not on a supported platform (Linux inotify or macOS FSEvents)
     // 2. The FILESENTRY_DISABLE environment variable is set (for testing)
-    let disable = !cfg!(target_os = "linux")
+    let disable = !(cfg!(target_os = "linux") || cfg!(target_os = "macos"))
         || std::env::var("FILESENTRY_DISABLE").is_ok();
 
     if disable {

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -1,0 +1,222 @@
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
+use std::sync::atomic::{self, AtomicBool};
+use std::sync::{Arc, Mutex};
+use std::{io, thread};
+
+mod sys;
+
+use crate::path::CanonicalPathBuf;
+use crate::pending::{self, PendingChangesLock};
+use crate::{Filter, WatcherState};
+
+use self::sys::{
+    EventLoopState, SendableCFRunLoopRef, K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_CREATED,
+    K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_INODE_META_MOD,
+    K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_IS_DIR, K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_IS_FILE,
+    K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_MODIFIED, K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_REMOVED,
+    K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_RENAMED,
+    K_FS_EVENT_STREAM_EVENT_FLAG_MUST_SCAN_SUB_DIRS,
+    K_FS_EVENT_STREAM_EVENT_ID_SINCE_NOW,
+};
+
+pub(crate) struct FseventWatcher {
+    run_loop: Mutex<Option<SendableCFRunLoopRef>>,
+    event_loop_state: Arc<EventLoopState>,
+    watched_roots: Mutex<Vec<CanonicalPathBuf>>,
+    pub changes: PendingChangesLock,
+}
+
+impl std::fmt::Debug for FseventWatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FseventWatcher")
+            .field("shutdown", &self.event_loop_state.shutdown)
+            .field("watched_roots", &self.watched_roots)
+            .field("changes", &self.changes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FseventWatcher {
+    pub fn shutdown(&self) {
+        self.event_loop_state
+            .shutdown
+            .store(true, atomic::Ordering::Relaxed);
+        self.wake_run_loop();
+        self.changes.notify();
+    }
+
+    pub fn is_shutdown(&self) -> bool {
+        self.event_loop_state
+            .shutdown
+            .load(atomic::Ordering::Relaxed)
+    }
+
+    pub fn new(
+        #[cfg(test)] _slow: bool,
+        state: Arc<WatcherState>,
+    ) -> io::Result<Arc<Self>> {
+        let event_loop_state = Arc::new(EventLoopState {
+            needs_restart: AtomicBool::new(false),
+            shutdown: AtomicBool::new(false),
+            last_event_id: std::sync::atomic::AtomicU64::new(
+                K_FS_EVENT_STREAM_EVENT_ID_SINCE_NOW,
+            ),
+            stream_generation: std::sync::Mutex::new(0),
+            stream_started: std::sync::Condvar::new(),
+        });
+
+        let watcher = Arc::new(Self {
+            run_loop: Mutex::new(None),
+            event_loop_state: event_loop_state.clone(),
+            watched_roots: Mutex::new(Vec::new()),
+            changes: PendingChangesLock::default(),
+        });
+
+        let filter: Arc<Mutex<Arc<dyn Filter>>> =
+            Arc::new(Mutex::new(state.config.lock().unwrap().filter.clone()));
+        let watcher_ = watcher.clone();
+
+        thread::spawn(move || {
+            sys::event_loop(
+                event_loop_state,
+                &watcher_.run_loop,
+                // get_paths: return null-terminated UTF-8 paths
+                {
+                    let watcher = watcher_.clone();
+                    move || {
+                        let roots = watcher.watched_roots.lock().unwrap();
+                        roots
+                            .iter()
+                            .map(|p: &CanonicalPathBuf| {
+                                let mut bytes = p.as_os_str().as_bytes().to_vec();
+                                bytes.push(0); // null-terminate for C
+                                bytes
+                            })
+                            .collect()
+                    }
+                },
+                // handler: process each event
+                {
+                    let watcher = watcher_.clone();
+                    let filter = filter.clone();
+                    move |path_bytes: &[u8], flags: sys::FSEventStreamEventFlags| {
+                        let filter = filter.lock().unwrap();
+                        watcher.handle_event(path_bytes, flags, &**filter);
+                    }
+                },
+                // notify: signal pending changes
+                {
+                    let watcher = watcher_.clone();
+                    move || {
+                        watcher.changes.notify();
+                    }
+                },
+                // handle_message: refresh config, check shutdown
+                {
+                    let watcher = watcher_.clone();
+                    move || {
+                        *filter.lock().unwrap() =
+                            state.config.lock().unwrap().filter.clone();
+                        watcher.is_shutdown()
+                    }
+                },
+            );
+        });
+
+        Ok(watcher)
+    }
+
+    pub fn watch_dir(&self, path: CanonicalPathBuf) -> io::Result<()> {
+        let mut roots = self.watched_roots.lock().unwrap();
+
+        // FSEvents is inherently recursive, so check if this path is already
+        // covered by an existing root
+        for root in roots.iter() {
+            if root.is_parent_of(&path) || *root == path {
+                return Ok(());
+            }
+        }
+
+        // Check if new root covers existing roots and remove them
+        roots.retain(|existing| !path.is_parent_of(existing));
+
+        roots.push(path);
+        drop(roots);
+
+        // Read current generation before triggering restart
+        let gen = self.event_loop_state.stream_generation.lock().unwrap();
+        let target = *gen + 1;
+        drop(gen);
+
+        self.event_loop_state
+            .needs_restart
+            .store(true, atomic::Ordering::Relaxed);
+        self.wake_run_loop();
+
+        // Wait until the event loop has actually (re)started the stream
+        let gen = self.event_loop_state.stream_generation.lock().unwrap();
+        let _gen = self
+            .event_loop_state
+            .stream_started
+            .wait_while(gen, |g| *g < target)
+            .unwrap();
+        Ok(())
+    }
+
+    pub fn refresh_config(&self) {
+        self.wake_run_loop();
+    }
+
+    fn wake_run_loop(&self) {
+        let guard = self.run_loop.lock().unwrap();
+        if let Some(ref rl) = *guard {
+            unsafe {
+                sys::CFRunLoopStop(rl.0);
+            }
+        }
+    }
+
+    fn handle_event(
+        &self,
+        path_bytes: &[u8],
+        flags: sys::FSEventStreamEventFlags,
+        filter: &dyn Filter,
+    ) {
+        if flags & K_FS_EVENT_STREAM_EVENT_FLAG_MUST_SCAN_SUB_DIRS != 0 {
+            self.changes.lock().recrawl();
+            return;
+        }
+
+        let path_os = OsStr::from_bytes(path_bytes);
+        let path = CanonicalPathBuf::assert_canonicalized(path_os.as_ref());
+
+        let is_dir = if flags & K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_IS_DIR != 0 {
+            Some(true)
+        } else if flags & K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_IS_FILE != 0 {
+            Some(false)
+        } else {
+            None
+        };
+
+        if filter.ignore_path(path.as_std_path(), is_dir) {
+            return;
+        }
+
+        let mut pending = self.changes.lock();
+        if flags
+            & (K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_CREATED
+                | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_REMOVED
+                | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_RENAMED)
+            != 0
+        {
+            pending.add_watcher(path, pending::Flags::NEEDS_RECURSIVE_CRAWL);
+        } else if flags
+            & (K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_MODIFIED
+                | K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_INODE_META_MOD)
+            != 0
+        {
+            pending.add_watcher(path, pending::Flags::empty());
+        }
+    }
+}

--- a/src/fsevent/sys.rs
+++ b/src/fsevent/sys.rs
@@ -1,0 +1,311 @@
+use std::ffi::{c_char, c_double, c_void, CStr};
+use std::ptr;
+use std::sync::atomic::{self, AtomicBool, AtomicU64};
+use std::sync::{Arc, Condvar, Mutex};
+
+// Core Foundation types
+#[repr(C)]
+pub struct __CFRunLoop(c_void);
+pub type CFRunLoopRef = *mut __CFRunLoop;
+
+#[repr(C)]
+pub struct __CFAllocator(c_void);
+pub type CFAllocatorRef = *const __CFAllocator;
+
+#[repr(C)]
+pub struct __CFString(c_void);
+pub type CFStringRef = *const __CFString;
+
+#[repr(C)]
+pub struct __CFArray(c_void);
+pub type CFArrayRef = *const __CFArray;
+
+pub type CFIndex = isize;
+pub type CFStringEncoding = u32;
+pub const K_CF_STRING_ENCODING_UTF8: CFStringEncoding = 0x08000100;
+
+// FSEvents types
+#[repr(C)]
+pub struct __FSEventStream(c_void);
+pub type FSEventStreamRef = *mut __FSEventStream;
+
+pub type FSEventStreamEventFlags = u32;
+pub type FSEventStreamEventId = u64;
+pub type FSEventStreamCreateFlags = u32;
+
+// Stream creation flags
+pub const K_FS_EVENT_STREAM_CREATE_FLAG_FILE_EVENTS: FSEventStreamCreateFlags = 0x00000010;
+pub const K_FS_EVENT_STREAM_CREATE_FLAG_NO_DEFER: FSEventStreamCreateFlags = 0x00000002;
+
+// Event flags
+pub const K_FS_EVENT_STREAM_EVENT_FLAG_MUST_SCAN_SUB_DIRS: FSEventStreamEventFlags = 0x00000001;
+pub const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_CREATED: FSEventStreamEventFlags = 0x00000100;
+pub const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_REMOVED: FSEventStreamEventFlags = 0x00000200;
+pub const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_INODE_META_MOD: FSEventStreamEventFlags = 0x00000400;
+pub const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_RENAMED: FSEventStreamEventFlags = 0x00000800;
+pub const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_MODIFIED: FSEventStreamEventFlags = 0x00001000;
+pub const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_IS_FILE: FSEventStreamEventFlags = 0x00010000;
+pub const K_FS_EVENT_STREAM_EVENT_FLAG_ITEM_IS_DIR: FSEventStreamEventFlags = 0x00020000;
+
+pub const K_FS_EVENT_STREAM_EVENT_ID_SINCE_NOW: FSEventStreamEventId = 0xFFFFFFFFFFFFFFFF;
+
+// CFArray callback structure
+#[repr(C)]
+pub struct CFArrayCallBacks {
+    pub version: CFIndex,
+    pub retain: *const c_void,
+    pub release: *const c_void,
+    pub copy_description: *const c_void,
+    pub equal: *const c_void,
+}
+
+// FSEventStreamContext
+#[repr(C)]
+pub struct FSEventStreamContext {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: Option<extern "C" fn(*const c_void) -> *const c_void>,
+    pub release: Option<extern "C" fn(*const c_void)>,
+    pub copy_description: Option<extern "C" fn(*const c_void) -> CFStringRef>,
+}
+
+pub type FSEventStreamCallback = extern "C" fn(
+    stream_ref: FSEventStreamRef,
+    client_callback_info: *mut c_void,
+    num_events: usize,
+    event_paths: *mut c_void,
+    event_flags: *const FSEventStreamEventFlags,
+    event_ids: *const FSEventStreamEventId,
+);
+
+#[link(name = "CoreServices", kind = "framework")]
+extern "C" {
+    pub static kCFRunLoopDefaultMode: CFStringRef;
+    pub static kCFAllocatorDefault: CFAllocatorRef;
+
+    pub fn CFRunLoopGetCurrent() -> CFRunLoopRef;
+    pub fn CFRunLoopRun();
+    pub fn CFRunLoopStop(rl: CFRunLoopRef);
+
+    pub fn CFStringCreateWithCString(
+        alloc: CFAllocatorRef,
+        c_str: *const c_char,
+        encoding: CFStringEncoding,
+    ) -> CFStringRef;
+    pub fn CFRelease(cf: *const c_void);
+
+    pub fn CFArrayCreate(
+        allocator: CFAllocatorRef,
+        values: *const *const c_void,
+        num_values: CFIndex,
+        callbacks: *const CFArrayCallBacks,
+    ) -> CFArrayRef;
+
+    pub fn FSEventStreamCreate(
+        allocator: CFAllocatorRef,
+        callback: FSEventStreamCallback,
+        context: *mut FSEventStreamContext,
+        paths_to_watch: CFArrayRef,
+        since_when: FSEventStreamEventId,
+        latency: c_double,
+        flags: FSEventStreamCreateFlags,
+    ) -> FSEventStreamRef;
+    pub fn FSEventStreamScheduleWithRunLoop(
+        stream_ref: FSEventStreamRef,
+        run_loop: CFRunLoopRef,
+        run_loop_mode: CFStringRef,
+    );
+    pub fn FSEventStreamStart(stream_ref: FSEventStreamRef) -> bool;
+    pub fn FSEventStreamStop(stream_ref: FSEventStreamRef);
+    pub fn FSEventStreamInvalidate(stream_ref: FSEventStreamRef);
+    pub fn FSEventStreamRelease(stream_ref: FSEventStreamRef);
+}
+
+// Safety: CFRunLoopRef can be sent to other threads for CFRunLoopStop
+pub struct SendableCFRunLoopRef(pub CFRunLoopRef);
+unsafe impl Send for SendableCFRunLoopRef {}
+unsafe impl Sync for SendableCFRunLoopRef {}
+
+/// State shared between the event loop thread and the callback.
+pub(super) struct EventLoopState {
+    pub needs_restart: AtomicBool,
+    pub shutdown: AtomicBool,
+    pub last_event_id: AtomicU64,
+    /// Incremented each time the stream is (re)started. Used with `stream_started`
+    /// to let `watch_dir` wait until the stream is actually running.
+    pub stream_generation: Mutex<u64>,
+    pub stream_started: Condvar,
+}
+
+/// Creates a CFArray of CFStringRef from the given paths.
+/// The caller is responsible for releasing the returned CFArrayRef and the individual CFStringRefs.
+unsafe fn create_cf_paths(
+    paths: &[Vec<u8>],
+) -> (CFArrayRef, Vec<CFStringRef>) {
+    let cf_strings: Vec<CFStringRef> = paths
+        .iter()
+        .map(|p| {
+            CFStringCreateWithCString(
+                kCFAllocatorDefault,
+                p.as_ptr() as *const c_char,
+                K_CF_STRING_ENCODING_UTF8,
+            )
+        })
+        .collect();
+    let ptrs: Vec<*const c_void> = cf_strings.iter().map(|s| *s as *const c_void).collect();
+    // Use kCFTypeArrayCallBacks equivalent: retain/release for CF types
+    let callbacks = CFArrayCallBacks {
+        version: 0,
+        retain: ptr::null(),
+        release: ptr::null(),
+        copy_description: ptr::null(),
+        equal: ptr::null(),
+    };
+    let array = CFArrayCreate(
+        kCFAllocatorDefault,
+        ptrs.as_ptr(),
+        ptrs.len() as CFIndex,
+        &callbacks,
+    );
+    (array, cf_strings)
+}
+
+/// The raw C callback invoked by FSEvents.
+extern "C" fn fsevent_callback(
+    _stream_ref: FSEventStreamRef,
+    client_callback_info: *mut c_void,
+    num_events: usize,
+    event_paths: *mut c_void,
+    event_flags: *const FSEventStreamEventFlags,
+    event_ids: *const FSEventStreamEventId,
+) {
+    unsafe {
+        let info = &*(client_callback_info as *const CallbackInfo);
+        let paths = event_paths as *const *const c_char;
+        let flags = std::slice::from_raw_parts(event_flags, num_events);
+        let ids = std::slice::from_raw_parts(event_ids, num_events);
+
+        for i in 0..num_events {
+            let path_cstr = CStr::from_ptr(*paths.add(i));
+            let path = path_cstr.to_bytes();
+            (info.handler)(path, flags[i]);
+        }
+
+        // Track the latest event ID for gap-free restarts
+        if let Some(&max_id) = ids.last() {
+            info.state.last_event_id.store(max_id, atomic::Ordering::Relaxed);
+        }
+
+        (info.notify)();
+    }
+}
+
+struct CallbackInfo {
+    handler: Box<dyn Fn(&[u8], FSEventStreamEventFlags) + Send + Sync>,
+    notify: Box<dyn Fn() + Send + Sync>,
+    state: Arc<EventLoopState>,
+}
+
+/// Run the FSEvents event loop on the current thread.
+/// `run_loop_out` receives the CFRunLoopRef once the loop starts so other threads can stop it.
+/// `get_paths` returns the current set of paths to watch (as null-terminated UTF-8 byte vectors).
+/// `handler` is called for each event with (path_bytes, event_flags).
+/// `notify` is called after processing a batch of events.
+/// `handle_message` is called when the run loop is woken; returns true to shut down.
+pub(super) fn event_loop(
+    state: Arc<EventLoopState>,
+    run_loop_out: &std::sync::Mutex<Option<SendableCFRunLoopRef>>,
+    get_paths: impl Fn() -> Vec<Vec<u8>>,
+    handler: impl Fn(&[u8], FSEventStreamEventFlags) + Send + Sync + 'static,
+    notify: impl Fn() + Send + Sync + 'static,
+    mut handle_message: impl FnMut() -> bool,
+) {
+    unsafe {
+        let current_loop = CFRunLoopGetCurrent();
+        *run_loop_out.lock().unwrap() = Some(SendableCFRunLoopRef(current_loop));
+
+        let callback_info = Box::new(CallbackInfo {
+            handler: Box::new(handler),
+            notify: Box::new(notify),
+            state: state.clone(),
+        });
+        let info_ptr = Box::into_raw(callback_info);
+
+        loop {
+            let paths = get_paths();
+            if paths.is_empty() {
+                // No paths to watch yet; block on the run loop waiting for a wake
+                // We need a dummy source to prevent CFRunLoopRun from returning immediately
+                CFRunLoopRun();
+                if state.shutdown.load(atomic::Ordering::Relaxed) {
+                    break;
+                }
+                if handle_message() {
+                    break;
+                }
+                continue;
+            }
+
+            let since_when = state.last_event_id.load(atomic::Ordering::Relaxed);
+
+            let (cf_paths, cf_strings) = create_cf_paths(&paths);
+
+            let mut context = FSEventStreamContext {
+                version: 0,
+                info: info_ptr as *mut c_void,
+                retain: None,
+                release: None,
+                copy_description: None,
+            };
+
+            let stream = FSEventStreamCreate(
+                kCFAllocatorDefault,
+                fsevent_callback,
+                &mut context,
+                cf_paths,
+                since_when,
+                0.0, // latency — immediate delivery
+                K_FS_EVENT_STREAM_CREATE_FLAG_FILE_EVENTS
+                    | K_FS_EVENT_STREAM_CREATE_FLAG_NO_DEFER,
+            );
+
+            FSEventStreamScheduleWithRunLoop(stream, current_loop, kCFRunLoopDefaultMode);
+            FSEventStreamStart(stream);
+
+            // Signal that the stream is running so watch_dir can proceed
+            {
+                let mut gen = state.stream_generation.lock().unwrap();
+                *gen += 1;
+            }
+            state.stream_started.notify_all();
+
+            // Release the CF path objects now that the stream owns them
+            for s in &cf_strings {
+                CFRelease(*s as *const c_void);
+            }
+            CFRelease(cf_paths as *const c_void);
+
+            // Block until CFRunLoopStop is called
+            CFRunLoopRun();
+
+            // Tear down the stream
+            FSEventStreamStop(stream);
+            FSEventStreamInvalidate(stream);
+            FSEventStreamRelease(stream);
+
+            if state.shutdown.load(atomic::Ordering::Relaxed) {
+                break;
+            }
+
+            if handle_message() {
+                break;
+            }
+
+            // Clear restart flag before looping to recreate stream with new paths
+            state.needs_restart.store(false, atomic::Ordering::Relaxed);
+        }
+
+        // Clean up callback info
+        drop(Box::from_raw(info_ptr));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,10 @@ use crate::config::Config;
 #[cfg(not(watcher_disable))]
 use crate::events::EventDebouncer;
 pub use crate::events::{Event, EventType, Events};
-#[cfg(not(watcher_disable))]
-use crate::inotify::InotifyWatcher;
+#[cfg(all(not(watcher_disable), target_os = "linux"))]
+use crate::inotify::InotifyWatcher as PlatformWatcher;
+#[cfg(all(not(watcher_disable), target_os = "macos"))]
+use crate::fsevent::FseventWatcher as PlatformWatcher;
 pub use crate::path::{CannonicalPath, CanonicalPathBuf};
 pub use config::Filter;
 
@@ -25,8 +27,10 @@ mod metadata;
 mod path;
 
 // These modules require the full Watcher implementation
-#[cfg(not(watcher_disable))]
+#[cfg(all(not(watcher_disable), target_os = "linux"))]
 mod inotify;
+#[cfg(all(not(watcher_disable), target_os = "macos"))]
+mod fsevent;
 #[cfg(not(watcher_disable))]
 mod pending;
 #[cfg(not(watcher_disable))]
@@ -70,7 +74,7 @@ struct WatcherState {
 
 #[cfg(not(watcher_disable))]
 pub struct ShutdownOnDrop {
-    watcher: Weak<InotifyWatcher>,
+    watcher: Weak<PlatformWatcher>,
 }
 
 #[cfg(not(watcher_disable))]
@@ -102,7 +106,7 @@ impl ShutdownOnDrop {
 #[derive(Debug, Clone)]
 pub struct Watcher {
     state: Arc<WatcherState>,
-    notify: Arc<InotifyWatcher>,
+    notify: Arc<PlatformWatcher>,
 }
 
 #[cfg(not(watcher_disable))]
@@ -197,9 +201,9 @@ impl Watcher {
             recrawls: AtomicUsize::new(0),
         });
         #[cfg(test)]
-        let watcher = InotifyWatcher::new(_slow, state.clone())?;
+        let watcher = PlatformWatcher::new(_slow, state.clone())?;
         #[cfg(not(test))]
-        let watcher = InotifyWatcher::new(state.clone())?;
+        let watcher = PlatformWatcher::new(state.clone())?;
 
         Ok(Self {
             state,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,6 +18,7 @@ static TIMEOUT: LazyLock<Duration> =
         _ => Duration::from_secs(20),
     });
 
+#[cfg(target_os = "linux")]
 pub static READ_DELAY: LazyLock<Duration> =
     LazyLock::new(|| match std::env::var("FILESENTRY_READ_DELAY") {
         Ok(res) if !res.trim().is_empty() => Duration::from_millis(
@@ -110,6 +111,7 @@ fn init_watcher() -> (TempDir, Watcher) {
     init_watcher_imp(false)
 }
 
+#[cfg(target_os = "linux")]
 fn init_watcher_slow() -> (TempDir, Watcher) {
     init_watcher_imp(true)
 }
@@ -131,10 +133,14 @@ fn init_watcher_imp(slow: bool) -> (TempDir, Watcher) {
 fn with_watcher(f: impl FnOnce(&Path, &Watcher)) {
     let (dir, watcher) = init_watcher();
     let shutdown_guard = watcher.shutdown_guard();
-    f(dir.path(), &watcher);
+    // Canonicalize to resolve symlinks (e.g., /var -> /private/var on macOS)
+    // so assertion paths match the canonical paths used internally.
+    let canonical = dir.path().canonicalize().unwrap();
+    f(&canonical, &watcher);
     drop(shutdown_guard)
 }
 
+#[cfg(target_os = "linux")]
 fn with_watcher_slow(f: impl FnOnce(&Path, &Watcher)) {
     let (dir, watcher) = init_watcher_slow();
     let shutdown_guard = watcher.shutdown_guard();
@@ -217,6 +223,7 @@ fn modify() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn queue_overflow() {
     with_watcher_slow(|dir, watcher| {
         let files: Vec<_> = (0..20_0000)


### PR DESCRIPTION
Adds a parallel fsevent module mirroring the inotify module structure, with conditional compilation to select the right backend per platform. Uses raw FFI to CoreServices framework (no new dependencies). Includes event ID tracking for gap-free stream restarts and condvar-based synchronization so watch_dir blocks until the stream is running.